### PR TITLE
added functions to work with OH rest/links/ endpoint

### DIFF
--- a/HABApp/openhab/definitions/rest/__init__.py
+++ b/HABApp/openhab/definitions/rest/__init__.py
@@ -1,3 +1,3 @@
 from .items import OpenhabItemDefinition
 from .things import OpenhabThingChannelDefinition, OpenhabThingDefinition, ThingNotEditableError, ThingNotFoundError
-from .links import ItemChannelLinkDefinition
+from .links import ItemChannelLinkDefinition, LinkNotFoundError

--- a/HABApp/openhab/http_connection.py
+++ b/HABApp/openhab/http_connection.py
@@ -331,7 +331,7 @@ class HttpConnection:
         else:
             return await ret.json(encoding='utf-8')
 
-    async def async_thing_remove_link(self, link_def: ItemChannelLinkDefinition) -> bool:
+    async def async_remove_link(self, link_def: ItemChannelLinkDefinition) -> bool:
         if self.config.general.listen_only:
             return False
 
@@ -340,7 +340,7 @@ class HttpConnection:
         ret = await self._check_http_response(fut)
         return ret.status == 200
 
-    async def async_thing_get_link(self, channel_uid: str, item_name: str) -> ItemChannelLinkDefinition:
+    async def async_get_link(self, channel_uid: str, item_name: str) -> ItemChannelLinkDefinition:
         fut = self.__session.get(self.__get_link_url(channel_uid, item_name))
         ret = await self._check_http_response(fut, accept_404=True)
         if ret.status == 404:
@@ -350,13 +350,13 @@ class HttpConnection:
         else:
             return ItemChannelLinkDefinition.parse_obj(await ret.json(encoding='utf-8'))
 
-    async def async_thing_link_exists(self, channel_uid: str, item_name: str) -> bool:
+    async def async_link_exists(self, channel_uid: str, item_name: str) -> bool:
         fut = self.__session.get(self.__get_link_url(channel_uid, item_name))
 
         ret = await self._check_http_response(fut, accept_404=True)
         return ret.status == 200
 
-    async def async_thing_add_link(self, link_def: ItemChannelLinkDefinition) -> bool:
+    async def async_create_link(self, link_def: ItemChannelLinkDefinition) -> bool:
         if self.config.general.listen_only:
             return False
 

--- a/HABApp/openhab/http_connection.py
+++ b/HABApp/openhab/http_connection.py
@@ -321,30 +321,34 @@ class HttpConnection:
         else:
             return await ret.json(encoding='utf-8')
 
-    async def async_remove_link(self, item_name, thing_UID, channel) -> bool:
+    async def async_thing_remove_link(self, thing_uid: str, channel: str, item_name: str) -> bool:
         if self.config.general.listen_only:
             return False
 
-        # rest/links/ endpoint needs the channel to be url encoded (AAAA:BBBB:CCCC:0#NAME -> AAAA%3ABBBB%3ACCCC%3A0%23NAME)
-        channelUID = urllib.parse.quote(thing_UID + ":" + channel)
-        url = self.__get_openhab_url('rest/links/{item:s}/{channel:s}',item=item_name,channel=channelUID)
+        # rest/links/ endpoint needs the channel to be url encoded 
+        # (AAAA:BBBB:CCCC:0#NAME -> AAAA%3ABBBB%3ACCCC%3A0%23NAME)
+        # otherwise the REST-api returns HTTP-Status 500 InternalServerError
+        channel_uid = urllib.parse.quote(f"{thing_uid}:{channel}")
+        url = self.__get_openhab_url('rest/links/{item:s}/{channel:s}', item=item_name, channel=channel_uid)
         
-        fut = self.__session.delete(url,json={})
+        fut = self.__session.delete(url, json={})
         
         ret = await self._check_http_response(fut)
         return ret.status == 200
 
-    async def async_link_exists(self, item_name, thing_UID, channel) -> bool:
-        # rest/links/ endpoint needs the channel to be url encoded (AAAA:BBBB:CCCC:0#NAME -> AAAA%3ABBBB%3ACCCC%3A0%23NAME)
-        channelUID = urllib.parse.quote(thing_UID + ":" + channel)
-        url = self.__get_openhab_url('rest/links/{item:s}/{channel:s}',item=item_name,channel=channelUID)
+    async def async_thing_link_exists(self, thing_uid: str, channel: str, item_name: str) -> bool:
+        # rest/links/ endpoint needs the channel to be url encoded 
+        # (AAAA:BBBB:CCCC:0#NAME -> AAAA%3ABBBB%3ACCCC%3A0%23NAME)
+        # otherwise the REST-api returns HTTP-Status 500 InternalServerError
+        channel_uid = urllib.parse.quote(f"{thing_uid}:{channel}")
+        url = self.__get_openhab_url('rest/links/{item:s}/{channel:s}', item=item_name, channel=channel_uid)
         
         fut = self.__session.get(url,json={})
 
-        ret = await self._check_http_response(fut)
+        ret = await self._check_http_response(fut, accept_404=True)
         return ret.status == 200
 
-    async def async_add_link(self, item_name, thing_UID, channel) -> bool:
+    async def async_thing_add_link(self, thing_uid: str, channel: str, item_name: str) -> bool:
         if self.config.general.listen_only:
             return False
 
@@ -353,11 +357,13 @@ class HttpConnection:
         if not exists:
             return False
         
-        # rest/links/ endpoint needs the channel to be url encoded (AAAA:BBBB:CCCC:0#NAME -> AAAA%3ABBBB%3ACCCC%3A0%23NAME)
-        channelUID = urllib.parse.quote(thing_UID + ":" + channel)
-        url = self.__get_openhab_url('rest/links/{item:s}/{channel:s}',item=item_name,channel=channelUID)
+        # rest/links/ endpoint needs the channel to be url encoded 
+        # (AAAA:BBBB:CCCC:0#NAME -> AAAA%3ABBBB%3ACCCC%3A0%23NAME)
+        # otherwise the REST-api returns HTTP-Status 500 InternalServerError
+        channel_uid = urllib.parse.quote(f"{thing_uid}:{channel}")
+        url = self.__get_openhab_url('rest/links/{item:s}/{channel:s}', item=item_name, channel=channel_uid)
         
-        fut = self.__session.put(url,json={})
+        fut = self.__session.put(url, json={})
 
         ret = await self._check_http_response(fut)
         return ret.status == 200

--- a/HABApp/openhab/oh_interface.py
+++ b/HABApp/openhab/oh_interface.py
@@ -214,26 +214,28 @@ class OpenhabInterface:
         data = fut.result()
         return OpenhabItemDefinition.parse_obj(data)
 
-    def thing_get_link(self, channel_uid: str, item_name: str) -> ItemChannelLinkDefinition:
-        """ returns the ItemChannelLinkDefinition for a link between a things channel and an item
+    def get_link(self, channel_uid: str, item_name: str) -> ItemChannelLinkDefinition:
+        """ returns the ItemChannelLinkDefinition for a link between a (things) channel and an item
 
-        :param channel_uid: uid of the channel (usually something like AAAA:BBBBB:CCCCC:DDDD:0#SOME_NAME)
+        :param channel_uid: uid of the (things) channel (usually something like AAAA:BBBBB:CCCCC:DDDD:0#SOME_NAME)
         :param item_name: name of the item
+        :return: an instance of ItemChannelLinkDefinition or None on error
         """
 
         assert isinstance(channel_uid, str), type(channel_uid)
         assert isinstance(item_name, str), type(item_name)
 
         fut = asyncio.run_coroutine_threadsafe(
-            self.__connection.async_thing_get_link(channel_uid, item_name),
+            self.__connection.async_get_link(channel_uid, item_name),
             loop
         )
         return fut.result()
 
-    def thing_add_link(self, link_def: ItemChannelLinkDefinition) -> bool:
-        """ adds a link between a things channel and an item
+    def create_link(self, link_def: ItemChannelLinkDefinition) -> bool:
+        """ creates a link between a (things) channel and an item
 
         :param link_def: an instance of ItemChannelLinkDefinition with at least channel_uid and item_name set
+        :return: true on successful creation, otherwise false
         """
 
         assert isinstance(link_def, ItemChannelLinkDefinition), type(link_def)
@@ -241,38 +243,40 @@ class OpenhabInterface:
         assert isinstance(link_def.channel_uid, str), type(link_def.channel_uid)
 
         fut = asyncio.run_coroutine_threadsafe(
-            self.__connection.async_thing_add_link(link_def),
+            self.__connection.async_create_link(link_def),
             loop
         )
         return fut.result()
 
-    def thing_remove_link(self, channel_uid: str, item_name: str) -> bool:
-        """ removes a link between a things channel and an item
+    def remove_link(self, channel_uid: str, item_name: str) -> bool:
+        """ removes a link between a (things) channel and an item
 
-        :param channel_uid: uid of the channel (usually something like AAAA:BBBBB:CCCCC:DDDD:0#SOME_NAME)
+        :param channel_uid: uid of the (things) channel (usually something like AAAA:BBBBB:CCCCC:DDDD:0#SOME_NAME)
         :param item_name: name of the item
+        :return: true on successful removal, otherwise false
         """
 
         link = ItemChannelLinkDefinition(itemName=item_name, channelUID=channel_uid)
 
         fut = asyncio.run_coroutine_threadsafe(
-            self.__connection.async_thing_remove_link(link),
+            self.__connection.async_remove_link(link),
             loop
         )
         return fut.result()
 
-    def thing_link_exists(self, channel_uid: str, item_name: str) -> bool:
+    def link_exists(self, channel_uid: str, item_name: str) -> bool:
         """ check if a things channel is linked to an item
 
         :param channel_uid: uid of the linked channel (usually something like AAAA:BBBBB:CCCCC:DDDD:0#SOME_NAME)
         :param item_name: name of the linked item
+        :return: true when the link exists, otherwise false
         """
 
         assert isinstance(channel_uid, str), type(channel_uid)
         assert isinstance(item_name, str), type(item_name)
 
         fut = asyncio.run_coroutine_threadsafe(
-            self.__connection.async_thing_link_exists(channel_uid, item_name),
+            self.__connection.async_link_exists(channel_uid, item_name),
             loop
         )
         return fut.result()

--- a/HABApp/openhab/oh_interface.py
+++ b/HABApp/openhab/oh_interface.py
@@ -213,6 +213,45 @@ class OpenhabInterface:
         data = fut.result()
         return OpenhabItemDefinition.parse_obj(data)
 
+    def add_link(self, item_name, thing_UID, channel) -> bool:
+        """ adds a link between an item and a things channel
+
+        :param item_name: name of the item
+        :param thing_UID: UID of the thing (usually something like AAAA:BBBBB:CCCCC:DDDD)
+        :param channel: name of the channel (usually something like 0#SOME_NAME or 1#SOME_NAME)
+        """
+        fut = asyncio.run_coroutine_threadsafe(
+            self.__connection.async_add_link(item_name,thing_UID,channel),
+            loop
+        )
+        return fut.result()
+
+    def remove_link(self, item_name, thing_UID, channel) -> bool:
+        """ removes a link between an item and a channel
+
+        :param item_name: name of the item
+        :param thing_UID: UID of the thing (usually something like AAAA:BBBBB:CCCCC:)
+        :param channel: name of the channel (usually something like 0#SOME_NAME or 1#SOME_NAME)
+        """
+        fut = asyncio.run_coroutine_threadsafe(
+            self.__connection.async_remove_link(item_name,thing_UID,channel),
+            loop
+        )
+        return fut.result()
+
+    def link_exists(self, item_name, thing_UID, channel) -> bool:
+        """ check if an item is linked to a things channel
+
+        :param item_name: name of the item
+        :param thing_UID: name of the thing (usually something like AAAA:BBBBB:CCCCC:)
+        :param channel: name of the channel (usually something like 0#SOME_NAME or 1#SOME_NAME)
+        """
+        fut = asyncio.run_coroutine_threadsafe(
+            self.__connection.async_link_exists(item_name,thing_UID,channel),
+            loop
+        )
+        return fut.result()
+
     @log_exception
     def remove_item(self, item_name: str):
         """

--- a/HABApp/openhab/oh_interface.py
+++ b/HABApp/openhab/oh_interface.py
@@ -213,41 +213,56 @@ class OpenhabInterface:
         data = fut.result()
         return OpenhabItemDefinition.parse_obj(data)
 
-    def add_link(self, item_name, thing_UID, channel) -> bool:
-        """ adds a link between an item and a things channel
+    def thing_add_link(self, thing_uid: str, channel: str, item_name: str) -> bool:
+        """ adds a link between a things channel and an item
 
+        :param thing_uid: uid of the thing (usually something like AAAA:BBBBB:CCCCC:DDDD)
+        :param channel: name of the channel (usually something like 0#SOME_NAME or #SOME_NAME)
         :param item_name: name of the item
-        :param thing_UID: UID of the thing (usually something like AAAA:BBBBB:CCCCC:DDDD)
-        :param channel: name of the channel (usually something like 0#SOME_NAME or 1#SOME_NAME)
         """
+
+        assert isinstance(thing_uid, str), type(thing_uid)
+        assert isinstance(channel, str), type(channel)
+        assert isinstance(item_name, str), type(item_name)
+
         fut = asyncio.run_coroutine_threadsafe(
-            self.__connection.async_add_link(item_name,thing_UID,channel),
+            self.__connection.async_thing_add_link(thing_uid, channel, item_name),
             loop
         )
         return fut.result()
 
-    def remove_link(self, item_name, thing_UID, channel) -> bool:
-        """ removes a link between an item and a channel
+    def thing_remove_link(self, thing_uid: str, channel: str, item_name: str) -> bool:
+        """ removes a link between a things channel and an item
 
+        :param thing_uid: uid of the thing (usually something like AAAA:BBBBB:CCCCC:DDDD)
+        :param channel: name of the channel (usually something like 0#SOME_NAME or #SOME_NAME)
         :param item_name: name of the item
-        :param thing_UID: UID of the thing (usually something like AAAA:BBBBB:CCCCC:)
-        :param channel: name of the channel (usually something like 0#SOME_NAME or 1#SOME_NAME)
         """
+
+        assert isinstance(thing_uid, str), type(thing_uid)
+        assert isinstance(channel, str), type(channel)
+        assert isinstance(item_name, str), type(item_name)
+
         fut = asyncio.run_coroutine_threadsafe(
-            self.__connection.async_remove_link(item_name,thing_UID,channel),
+            self.__connection.async_thing_remove_link(thing_uid, channel, item_name),
             loop
         )
         return fut.result()
 
-    def link_exists(self, item_name, thing_UID, channel) -> bool:
-        """ check if an item is linked to a things channel
+    def thing_link_exists(self, thing_uid: str, channel: str, item_name: str) -> bool:
+        """ check if a things channel is linked to an item
 
+        :param thing_uid: uid of the thing (usually something like AAAA:BBBBB:CCCCC:DDDD)
+        :param channel: name of the channel (usually something like 0#SOME_NAME or #SOME_NAME)
         :param item_name: name of the item
-        :param thing_UID: name of the thing (usually something like AAAA:BBBBB:CCCCC:)
-        :param channel: name of the channel (usually something like 0#SOME_NAME or 1#SOME_NAME)
         """
+
+        assert isinstance(thing_uid, str), type(thing_uid)
+        assert isinstance(channel, str), type(channel)
+        assert isinstance(item_name, str), type(item_name)
+
         fut = asyncio.run_coroutine_threadsafe(
-            self.__connection.async_link_exists(item_name,thing_UID,channel),
+            self.__connection.async_thing_link_exists(thing_uid, channel, item_name),
             loop
         )
         return fut.result()

--- a/conf_testing/rules/test_openhab_interface_links.py
+++ b/conf_testing/rules/test_openhab_interface_links.py
@@ -1,0 +1,97 @@
+import HABApp
+from HABApp.core.Items import get_all_items
+from HABApp.openhab.definitions.rest import ItemChannelLinkDefinition, LinkNotFoundError
+from HABApp.openhab.items import Thing
+from conf_testing.lib.HABAppTests import ItemWaiter, OpenhabTmpItem, TestBaseRule, get_openhab_test_states, get_openhab_test_types
+
+class TestOpenhabInterfaceLinks(TestBaseRule):
+    astro_sun_thing: str
+    item_name: str
+    channel_uid: str
+
+    def __init__(self):
+        super().__init__()
+
+        self.item_name = "TestOpenhabInterfaceLinksItem"
+        self.channel_uid = f"{self.astro_sun_thing}:rise:duration"
+
+        self.astro_sun_thing = self.__find_astro_sun_thing()
+        if self.astro_sun_thing == "":
+            raise Exception("no astro:sun thing found")
+        
+        self.__create_test_item()
+        if not self.openhab.item_exists(self.item_name):
+            raise Exception("item could not be created")
+
+        self.add_test(f"link creation", self.test_create_link)
+        self.add_test(f"created link is gettable and equal", self.test_get_link)
+        self.add_test(f"link existence", self.test_link_existence)
+        self.add_test(f"link removal", self.test_remove_link)
+        self.add_test(f"link update", self.test_update_link)
+
+    def __create_test_item(self):
+        self.openhab.create_item("Number", self.item_name)
+
+    def __get_link_def(self) -> ItemChannelLinkDefinition:
+        return ItemChannelLinkDefinition(channelUID=self.channel_uid, itemName=self.item_name,
+                    configuration={"profile": "system:default"})
+
+    def tear_down(self):
+        if self.oh.link_exists(self.channel_uid, self.item_name):
+            self.oh.remove_link(self.channel_uid, self.item_name)
+
+        self.openhab.remove_item(self.item_name)
+
+    def __find_astro_sun_thing(self) -> str:
+        found_uid: str = ""
+        for item in get_all_items():
+            if isinstance(item, Thing) and item.name.startswith("astro:sun"):
+                found_uid = item.name
+
+        return found_uid
+
+    def test_update_link(self):        
+        created = self.oh.create_link(self.__get_link_def())
+        assert created
+
+        changed_def = self.__get_link_def()
+        changed_def.configuration["profile"] = "system:offset"
+        changed_def.configuration["offset"] = 7.0
+
+        changed_created = self.oh.create_link(changed_def)
+        assert changed_created
+
+        assert self.oh.get_link(self.channel_uid, self.item_name) == changed_def
+
+    def test_get_link(self):
+        self.oh.create_link(self.__get_link_def())
+        link = self.oh.get_link(self.channel_uid, self.item_name)
+
+        assert link is not None
+        assert link == self.__get_link_def()
+
+    def test_remove_link(self):
+        created = self.oh.create_link(self.__get_link_def())
+        assert created
+
+        removed = self.oh.remove_link(self.channel_uid, self.item_name)
+        assert removed
+
+        assert not self.oh.link_exists(self.channel_uid, self.item_name)
+
+    def test_link_existence(self):
+        created = self.oh.create_link(self.__get_link_def())
+        assert created
+
+        assert self.oh.link_exists(self.channel_uid, self.item_name)
+        
+        removed = self.oh.remove_link(self.channel_uid, self.item_name)
+        assert removed
+
+        assert not self.oh.link_exists(self.channel_uid, self.item_name)
+
+    def test_create_link(self):
+        created = self.oh.create_link(self.__get_link_def())
+        assert created
+
+TestOpenhabInterfaceLinks()


### PR DESCRIPTION
Hi @spacemanspiff2007 

Here is my first try for a pull request.

A few notes regarding the changes:
- i changed the parameter name from thing_name to thing_uid as this is what is actually used (we could of course change this to the thing_name and look the UID up via async_get_thing before accessing the links-endpoint)
- the thing UID is in a format like AAAAAA:BBBBBB:CCCCCCC:DDDDD which needs to be URL-encoded to be able to work with the api (I'm doing this using urllib.parse.quote(url)

Before I found the missing encoding to be the issue I always got the OpenHabNotReadyYetException from _check_http_response. This occurs because you say that OpenHAB is not ready when there is a http-response-status 500 which means InternalServerError but could actually be anything. 

Also I'm not sure about error handling and exceptions and what to propagate to the caller and what not. On any errors except disconnection the functions currently would return false without any possibility for the caller to get the error besides looking in the logs.