### PR TITLE
correct syntax of event listener function

### DIFF
--- a/_doc/parameters.rst
+++ b/_doc/parameters.rst
@@ -40,7 +40,7 @@ Parameters are perfect for boundaries (e.g. if value is below param switch somet
 
             self.listen_event('test_item', self.on_change_event, HABApp.core.events.ValueChangeEvent)
 
-        def on_change_event( event):
+        def on_change_event(self, event):
 
             # the parameter can be used like a normal variable, comparison works as expected
             if self.min_value < event.value:

--- a/_doc/rule.rst
+++ b/_doc/rule.rst
@@ -94,12 +94,12 @@ Example::
         # If you already have an item you can use the more convenient method of the item
         # to listen to the item events
         my_item = Item.get_item('MyItem')
-        my_item.listen_event(self.item_changed, ValueUpdateEvent)
+        my_item.listen_event(self.on_change, ValueUpdateEvent)
 
-    def on_change(event):
+    def on_change(self, event):
         assert isinstance(event, ValueChangeEvent), type(event)
 
-    def on_update(event):
+    def on_update(self, event):
         assert isinstance(event, ValueUpdateEvent), type(event)
 
 Scheduler


### PR DESCRIPTION
there is the parameter "self" missing for the event handler functions in some of the documentation pages:
* parameters.rst
* rule.rst

Signed-off-by: Michael Roßner <Schrott.Micha@web.de>

