### PR TITLE
Fix DateTime string parsing for OH 3.1

### DIFF
--- a/HABApp/openhab/map_items.py
+++ b/HABApp/openhab/map_items.py
@@ -61,7 +61,13 @@ def map_item(name, openhab_type: str, openhab_value: str) -> typing.Optional[Bas
         if openhab_type == "DateTime":
             if value is None:
                 return DatetimeItem(name, value)
-            dt = datetime.datetime.strptime(value.replace('+', '000+'), '%Y-%m-%dT%H:%M:%S.%f%z')
+            # Previous OH versions used a datetime string like this:
+            # 2018-11-19T09:47:38.284+0100
+            # OH 3.1 uses
+            # 2021-04-10T22:00:43.043996+0200 
+            if len(value)==28:
+                value = value.replace('+', '000+')
+            dt = datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f%z')
             # all datetimes from openhab have a timezone set so we can't easily compare them
             # --> TypeError: can't compare offset-naive and offset-aware datetimes
             dt = dt.astimezone(tz=None)   # Changes datetime object so it uses system timezone

--- a/HABApp/openhab/map_items.py
+++ b/HABApp/openhab/map_items.py
@@ -64,8 +64,8 @@ def map_item(name, openhab_type: str, openhab_value: str) -> typing.Optional[Bas
             # Previous OH versions used a datetime string like this:
             # 2018-11-19T09:47:38.284+0100
             # OH 3.1 uses
-            # 2021-04-10T22:00:43.043996+0200 
-            if len(value)==28:
+            # 2021-04-10T22:00:43.043996+0200
+            if len(value) == 28:
                 value = value.replace('+', '000+')
             dt = datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f%z')
             # all datetimes from openhab have a timezone set so we can't easily compare them

--- a/HABApp/openhab/map_values.py
+++ b/HABApp/openhab/map_values.py
@@ -21,8 +21,13 @@ def map_openhab_values(openhab_type: str, openhab_value: str):
             return float(openhab_value)
 
     if openhab_type == "DateTime":
+        # Previous OH versions used a datetime string like this:
         # 2018-11-19T09:47:38.284+0100
-        dt = datetime.datetime.strptime(openhab_value.replace('+', '000+'), '%Y-%m-%dT%H:%M:%S.%f%z')
+        # OH 3.1 uses
+        # 2021-04-10T22:00:43.043996+0200 
+        if len(openhab_value)==28:
+            openhab_value = openhab_value.replace('+', '000+')
+        dt = datetime.datetime.strptime(openhab_value, '%Y-%m-%dT%H:%M:%S.%f%z')
         # all datetimes from openhab have a timezone set so we can't easily compare them
         # --> TypeError: can't compare offset-naive and offset-aware datetimes
         dt = dt.astimezone(tz=None)   # Changes datetime object so it uses system timezone

--- a/HABApp/openhab/map_values.py
+++ b/HABApp/openhab/map_values.py
@@ -24,8 +24,8 @@ def map_openhab_values(openhab_type: str, openhab_value: str):
         # Previous OH versions used a datetime string like this:
         # 2018-11-19T09:47:38.284+0100
         # OH 3.1 uses
-        # 2021-04-10T22:00:43.043996+0200 
-        if len(openhab_value)==28:
+        # 2021-04-10T22:00:43.043996+0200
+        if len(openhab_value) == 28:
             openhab_value = openhab_value.replace('+', '000+')
         dt = datetime.datetime.strptime(openhab_value, '%Y-%m-%dT%H:%M:%S.%f%z')
         # all datetimes from openhab have a timezone set so we can't easily compare them


### PR DESCRIPTION
OH 3.1 seems to use a different DateTime string which causes a parsing error in HABApp.

refer to issue in: https://community.openhab.org/t/date-parse-error-with-timestamp-on-update-profile-in-oh3/120538

With this change the addition "000" for the microseconds are only added if the provided datestring is only 28 characters long.