### PR TITLE
Refix Dockerfile CMD line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ WORKDIR ${HABAPP_HOME}
 VOLUME ["${HABAPP_HOME}/config"]
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["gosu", "habapp", "tini", "--", "python", "-m", "HABApp", "--config", "/habapp/config"]
+CMD ["gosu", "habapp", "tini", "--", "python", "-m", "HABApp", "--config", "./config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ WORKDIR ${HABAPP_HOME}
 VOLUME ["${HABAPP_HOME}/config"]
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["gosu", "habapp", "tini", "--", "python", "-m", "HABApp", "--config", "/${HABAPP_HOME}/config"]
+CMD ["gosu", "habapp", "tini", "--", "python", "-m", "HABApp", "--config", "/habapp/config"]


### PR DESCRIPTION
I have seen you have done some changes to the Dockerfile.

Unfortunately there is no environment variables expansion inside the CMD part of a Dockerfile, because there is no shell used like bash or sh. For this your change will break the things. 

But I noticed what works fine is using ./config instead because we set the correct WORKDIR

Signed-off-by: Johannes Ott <mail@johannes-ott.net>