### PR TITLE
Fixed eventfilter to work with OH 3.3

### DIFF
--- a/src/HABApp/openhab/connection_handler/http_connection.py
+++ b/src/HABApp/openhab/connection_handler/http_connection.py
@@ -225,8 +225,8 @@ async def start_sse_event_listener():
 
         async with sse_client.EventSource(
                 url='/rest/events?topics='
-                    'openhab/items/,'       # Item updates
-                    'openhab/channels/,'    # Channel update
+                    'openhab/items/*,'       # Item updates
+                    'openhab/channels/*,'    # Channel update
 
                     # Thing events - don't listen to updated events
                     # 'openhab/things/*',


### PR DESCRIPTION
Apparently the eventfilter in OH 3.3 now does not do a prefix match anymore but requires an explicit wildcard.

Without this change HABApp does not recieve any Item events.

Trivial snippet to test the code:

`import requests
url='http://openhab:8080/rest/events?topics=' \
    'openhab/items/*,'   \
   'openhab/channels/*,' \
   'openhab/things/*/added,' \
   'openhab/things/*/removed,' \
   'openhab/things/*/status,' \
   'openhab/things/*/statuschanged'
print (url)
r = requests.get(url,stream=True)
if r.encoding is None:
    r.encoding = 'utf-8'
for line in r.iter_lines(decode_unicode=True):
    if line:
        print (line)`