### PR TITLE
Update config.yml

### DIFF
--- a/run/conf/config.yml
+++ b/run/conf/config.yml
@@ -38,8 +38,8 @@ openhab:
     interval: 10       # Seconds between two pings
   connection:
     url: http://localhost:8080   # Connect to this url
-    user: 'asdf'
-    password: 'asdf'
+    user: 'asdf'                 # Your username instead of asdf here,
+    password: 'asdf'             # and your password (as for logging in to the MainUI) or suffer a 401 connection error
     verify_ssl: true             # Check certificates when using https
   general:
     listen_only: false      # If True HABApp does not change anything on the openHAB instance.


### PR DESCRIPTION
Added comment to connection parameters for openhab to aid newcomers in configuring HABapp. 
It probably took me half an hour (would have been much longer if not for this (https://community.openhab.org/t/habapp-1-0-6-with-openhab-3-4-no-access-to-rest-api/142457/1) post to figure this out.
Related to issue #350 .