### PR TITLE
added ability to listen to all events

### DIFF
--- a/src/HABApp/core/const/topics.py
+++ b/src/HABApp/core/const/topics.py
@@ -4,12 +4,13 @@ from typing import Final, Tuple
 TOPIC_INFOS: Final    = 'HABApp.Infos'
 TOPIC_WARNINGS: Final = 'HABApp.Warnings'
 TOPIC_ERRORS: Final   = 'HABApp.Errors'
+TOPIC_ANY: Final      = 'HABApp.Any'
 
 TOPIC_FILES: Final = 'HABApp.Files'
 
 
 ALL_TOPICS: Tuple[str, ...] = (
-    TOPIC_INFOS, TOPIC_WARNINGS, TOPIC_ERRORS,
+    TOPIC_INFOS, TOPIC_WARNINGS, TOPIC_ERRORS, TOPIC_ANY,
 
     TOPIC_FILES
 )

--- a/src/HABApp/core/internals/event_bus/event_bus.py
+++ b/src/HABApp/core/internals/event_bus/event_bus.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 from HABApp.core.events import ComplexEventValue, ValueChangeEvent
 from .base_listener import EventBusBaseListener
 from HABApp.core.const.log import TOPIC_EVENTS
+from HABApp.core.const.topics import TOPIC_ANY
 
 event_log = logging.getLogger(TOPIC_EVENTS)
 habapp_log = logging.getLogger('HABApp')
@@ -42,6 +43,11 @@ class EventBus:
 
         # Notify all listeners
         listeners = self._listeners.get(topic, None)
+        if listeners is not None:
+            for listener in listeners:
+                listener.notify_listeners(event)
+        # Notify all catch all listeners
+        listeners = self._listeners.get(TOPIC_ANY, None)
         if listeners is not None:
             for listener in listeners:
                 listener.notify_listeners(event)

--- a/src/HABApp/rule/rule.py
+++ b/src/HABApp/rule/rule.py
@@ -101,14 +101,14 @@ class Rule(ContextProvidingObj):
             event
         )
 
-    def listen_event(self, name: Union[HINT_ITEM_OBJ, str],
+    def listen_event(self, name: Union[HINT_ITEM_OBJ, str, None],
                      callback: HINT_EVENT_CALLBACK,
                      event_filter: Optional[HINT_EVENT_FILTER_OBJ] = None
                      ) -> HINT_EVENT_BUS_LISTENER:
         """
         Register an event listener
 
-        :param name: item or name to listen to
+        :param name: item or name to listen to. If name is None the listener will listen to all events
         :param callback: callback that accepts one parameter which will contain the event
         :param event_filter: Event filter. This is typically :class:`~HABApp.core.events.ValueUpdateEventFilter` or
             :class:`~HABApp.core.events.ValueChangeEventFilter` which will also trigger on changes/update from openhab


### PR DESCRIPTION
For scenarios where not all possible items are know upfront it might be beneficial to be able to listen to all events on the bus. 
This change adds the ability to add a catch all event listener by specifying the topic HABApp.Any
