### PR TITLE
Allow optional channel type

### DIFF
--- a/src/HABApp/openhab/definitions/rest/things.py
+++ b/src/HABApp/openhab/definitions/rest/things.py
@@ -12,7 +12,7 @@ class ChannelResp(Struct, kw_only=True):
 
     uid: str
     id: str
-    channel_type: str = field(name='channelTypeUID')
+    channel_type: Optional[str] = field(default=None, name='channelTypeUID')
     item_type: Optional[str] = field(default=None, name='itemType')
     kind: str
     label: str = ''


### PR DESCRIPTION
A small fix for the type system. It seems there are things having channels without a `channelTypeUID`.

Here a brief snippet from my configuration:
```json
  {
    "channels": [
      {
        "linkedItems": [
          "RoofTop_Stairwell_Shutter"
        ],
        "uid": "somfytahoma:rollershutter:48ca8db4:3d816fbc-d9b5-4d52-883f-34c5744e3974:control",
        "id": "control",
        "channelTypeUID": "somfytahoma:control",
        "itemType": "Rollershutter",
        "kind": "STATE",
        "label": "Control",
        "description": "Device control (UP, DOWN, MY/STOP, closure 0-100%)",
        "defaultTags": [],
        "properties": {},
        "configuration": {}
      },
      {
        "linkedItems": [],
        "uid": "somfytahoma:rollershutter:48ca8db4:3d816fbc-d9b5-4d52-883f-34c5744e3974:rssi",
        "id": "rssi",
        "itemType": "Number",
        "kind": "STATE",
        "label": "RSSI Level",
        "defaultTags": [],
        "properties": {},
        "configuration": {}
      }
    ],
    "statusInfo": {
      "status": "ONLINE",
      "statusDetail": "NONE"
    },
    "editable": true,
    "label": "Homecontrol: Treppenhaus",
    "bridgeUID": "somfytahoma:bridge:48ca8db4",
    "configuration": {
      "url": "io://0817-5347-9274/4909609"
    },
    "properties": {
      "core:Memorized1PositionState": "0.0",
      "core:StatusState": "available",
      "core:ClosureState": "100.0",
      "core:NameState": "Treppenhaus",
      "label": "Treppenhaus",
      "core:OpenClosedState": "closed",
      "core:CommandLockLevelsState": "[]",
      "io:PriorityLockLevelState": "java.lang.Object@1e2c656",
      "core:PriorityLockTimerState": "0.0",
      "core:DiscreteRSSILevelState": "normal",
      "io:PriorityLockOriginatorState": "java.lang.Object@55ef8c",
      "core:RSSILevelState": "52.0"
    },
    "UID": "somfytahoma:rollershutter:48ca8db4:3d816fbc-d9b5-4d52-883f-34c5744e3974",
    "thingTypeUID": "somfytahoma:rollershutter"
  }
```

addressing the error I got on startup:

```
Error Object missing required field `channelTypeUID` - at `$[4].channels[1]` in on_connected:
File "$HOME/Code/homeautomation/habapp/lib/python3.11/site-packages/HABApp/openhab/connection/plugins/load_items.py", line 30 in on_connected
...
```