### PR TITLE
Fix proposal for #501

### DIFF
--- a/src/HABApp/openhab/definitions/websockets/item_value_types.py
+++ b/src/HABApp/openhab/definitions/websockets/item_value_types.py
@@ -158,7 +158,12 @@ class HSBTypeModel(ItemValueBase):
     @override
     @staticmethod
     def get_value_from_state(state: str) -> HSB:
-        return HSBTypeModel(type='HSB', value=state).get_value()
+        try:
+            # Try to parse the value normally
+            return HSBTypeModel(type='HSB', value=state).get_value()
+        except ValueError:
+            # Return black (0,0,0) as default for any invalid value
+            return HSB(0, 0, 0)
 
     # noinspection PyNestedDecorators
     @override


### PR DESCRIPTION
If HSB values are malformed use default value.

* HSB parsing — return HSB(0,0,0) for malformed values (safe default)

this prevents endless restart of the connection --> see #501 